### PR TITLE
Accept options for the rebase command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
   exclude-drafts:
     description: 'Exclude draft pull requests'
     default: false
+  rebase-options:
+    description: >
+      Additional options to pass to the git rebase command.
+      For example, to always prefer "their" code, use "-Xtheirs" ("--strategy-option=theirs").
+      Pass multiple options as a single string separated by commas or newlines.
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -399,7 +399,8 @@ function run() {
                 base: core.getInput('base'),
                 includeLabels: utils.getInputAsArray('include-labels'),
                 excludeLabels: utils.getInputAsArray('exclude-labels'),
-                excludeDrafts: core.getInput('exclude-drafts') === 'true'
+                excludeDrafts: core.getInput('exclude-drafts') === 'true',
+                rebaseOptions: utils.getInputAsArray('rebase-options')
             };
             core.debug(`Inputs: ${(0, util_1.inspect)(inputs)}`);
             const [headOwner, head] = inputValidator.parseHead(inputs.head);
@@ -418,7 +419,7 @@ function run() {
                 // Rebase
                 // Create a git command manager
                 const git = yield git_command_manager_1.GitCommandManager.create(sourceSettings.repositoryPath);
-                const rebaseHelper = new rebase_helper_1.RebaseHelper(git);
+                const rebaseHelper = new rebase_helper_1.RebaseHelper(git, inputs.rebaseOptions);
                 let rebasedCount = 0;
                 for (const pull of pulls) {
                     const result = yield rebaseHelper.rebase(pull);
@@ -625,8 +626,9 @@ exports.RebaseHelper = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const uuid_1 = __nccwpck_require__(5840);
 class RebaseHelper {
-    constructor(git) {
+    constructor(git, options) {
         this.git = git;
+        this.extraOptions = options;
     }
     rebase(pull) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -688,7 +690,11 @@ class RebaseHelper {
     tryRebase(remoteName, ref) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const result = yield this.git.exec(['rebase', `${remoteName}/${ref}`]);
+                const result = yield this.git.exec([
+                    'rebase',
+                    ...this.extraOptions,
+                    `${remoteName}/${ref}`
+                ]);
                 return result ? RebaseResult.Rebased : RebaseResult.AlreadyUpToDate;
             }
             catch (_a) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,8 @@ async function run(): Promise<void> {
       base: core.getInput('base'),
       includeLabels: utils.getInputAsArray('include-labels'),
       excludeLabels: utils.getInputAsArray('exclude-labels'),
-      excludeDrafts: core.getInput('exclude-drafts') === 'true'
+      excludeDrafts: core.getInput('exclude-drafts') === 'true',
+      rebaseOptions: utils.getInputAsArray('rebase-options')
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 
@@ -51,7 +52,7 @@ async function run(): Promise<void> {
       // Rebase
       // Create a git command manager
       const git = await GitCommandManager.create(sourceSettings.repositoryPath)
-      const rebaseHelper = new RebaseHelper(git)
+      const rebaseHelper = new RebaseHelper(git, inputs.rebaseOptions)
       let rebasedCount = 0
       for (const pull of pulls) {
         const result = await rebaseHelper.rebase(pull)

--- a/src/rebase-helper.ts
+++ b/src/rebase-helper.ts
@@ -5,9 +5,11 @@ import {v4 as uuidv4} from 'uuid'
 
 export class RebaseHelper {
   private git: GitCommandManager
+  private extraOptions: string[]
 
-  constructor(git: GitCommandManager) {
+  constructor(git: GitCommandManager, options: string[]) {
     this.git = git
+    this.extraOptions = options
   }
 
   async rebase(pull: Pull): Promise<boolean> {
@@ -86,7 +88,11 @@ export class RebaseHelper {
     ref: string
   ): Promise<RebaseResult> {
     try {
-      const result = await this.git.exec(['rebase', `${remoteName}/${ref}`])
+      const result = await this.git.exec([
+        'rebase',
+        ...this.extraOptions,
+        `${remoteName}/${ref}`
+      ])
       return result ? RebaseResult.Rebased : RebaseResult.AlreadyUpToDate
     } catch {
       return RebaseResult.Failed


### PR DESCRIPTION
Our use case also required `-Xtheirs`, so I implemented it. Let me know if anything should be updated. I reused `utils.getInputAsArray` to split arguments and documented the behavior, but if there's a better way to do this let me know so I can fix it. I wanted to do whitespace first, but thinking about interactions between single and double quotes, etc, it just is much easier to delimit by newline.

Closes #114 