### PR TITLE
Continue rebasing remaining PRs when one fails

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -421,16 +421,26 @@ function run() {
                 const git = yield git_command_manager_1.GitCommandManager.create(sourceSettings.repositoryPath);
                 const rebaseHelper = new rebase_helper_1.RebaseHelper(git, inputs.rebaseOptions);
                 let rebasedCount = 0;
+                const failedRefs = [];
                 for (const pull of pulls) {
-                    const result = yield rebaseHelper.rebase(pull);
-                    if (result)
-                        rebasedCount++;
+                    try {
+                        const result = yield rebaseHelper.rebase(pull);
+                        if (result)
+                            rebasedCount++;
+                    }
+                    catch (error) {
+                        failedRefs.push(pull.headRef);
+                        core.error(`Failed to rebase '${pull.headRef}': ${utils.getErrorMessage(error)}`);
+                    }
                 }
                 // Output count of successful rebases
                 core.setOutput('rebased-count', rebasedCount);
                 // Delete the repository
                 core.debug(`Removing repo at '${sourceSettings.repositoryPath}'`);
                 yield io.rmRF(sourceSettings.repositoryPath);
+                if (failedRefs.length > 0) {
+                    core.setFailed(`Failed to rebase the following head ref(s): ${failedRefs.join(', ')}`);
+                }
             }
             else {
                 core.info('No pull requests found.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,9 +54,19 @@ async function run(): Promise<void> {
       const git = await GitCommandManager.create(sourceSettings.repositoryPath)
       const rebaseHelper = new RebaseHelper(git, inputs.rebaseOptions)
       let rebasedCount = 0
+      const failedRefs: string[] = []
       for (const pull of pulls) {
-        const result = await rebaseHelper.rebase(pull)
-        if (result) rebasedCount++
+        try {
+          const result = await rebaseHelper.rebase(pull)
+          if (result) rebasedCount++
+        } catch (error) {
+          failedRefs.push(pull.headRef)
+          core.error(
+            `Failed to rebase '${pull.headRef}': ${utils.getErrorMessage(
+              error
+            )}`
+          )
+        }
       }
 
       // Output count of successful rebases
@@ -65,6 +75,12 @@ async function run(): Promise<void> {
       // Delete the repository
       core.debug(`Removing repo at '${sourceSettings.repositoryPath}'`)
       await io.rmRF(sourceSettings.repositoryPath)
+
+      if (failedRefs.length > 0) {
+        core.setFailed(
+          `Failed to rebase the following head ref(s): ${failedRefs.join(', ')}`
+        )
+      }
     } else {
       core.info('No pull requests found.')
     }


### PR DESCRIPTION
Fixes #178.

A thrown push escaped the per-PR loop in `main.ts` and aborted every remaining PR. The most common trigger is a PR that changes `.github/workflows/**` when the token lacks the `workflow` scope: the rebase succeeds but the force-push is rejected.

Each PR is now rebased in its own try/catch. A failure is logged and recorded, the run continues, and the action is marked failed at the end if any head ref failed. This mirrors how rebase conflicts are already isolated per PR.

`dist/index.js` rebuilt; `lint`, `format-check`, and `test` pass.